### PR TITLE
Revert unnecessary / mistaken minSDkVersion bump to 26 to fix #1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
     }
     defaultConfig {
         targetSdkVersion 33
-        minSdkVersion 26
+        minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
This reverts commit 53e8462a23fc8bc5a644ecb33594738cd8c77826. The minSDKVersion bump is not needed because both calls to `ZoneId` are guarded by SDK level check as pointed out in #1!