### PR TITLE
Use desugaring with AGP update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * **Breaking change** bumped minimum Flutter SDK requirement to 3.0.0
 * Updated AGP to 7.3.1 and use desugaring to allowing use of the newer Java time APIs on all the Android versions supported by the plugin
+* Removed Android v1 embedding references
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+* **Breaking change** bumped minimum Flutter SDK requirement to 3.0.0
+* Updated AGP to 7.3.1 and use desugaring to allowing use of the newer Java time APIs on all the Android versions supported by the plugin
+
 ## 1.0.4
 
 Revert Android minSDKVersion to 23 since calls to newer APIs are guarded.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,27 @@ This is a fork of the original [flutter_native_timezone](https://pub.dev/package
 
 ## Getting Started
 
-Install this package and everything good will just follow along with you.
+Install this package and update the `build.gradle` file of your Android app to enable [desugaring](https://developer.android.com/studio/releases/gradle-plugin#j8-library-desugaring). Please see the link on desugaring for details but the main parts needed in this Gradle file would be
+
+```gradle
+android {
+  defaultConfig {
+    multiDexEnabled true
+  }
+
+  compileOptions {
+    // Flag to enable support for the new language APIs
+    coreLibraryDesugaringEnabled true
+    // Sets Java compatibility to Java 8
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+}
+
+dependencies {
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.0'
+}
+```
 
 ## Usage examples
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -27,10 +27,17 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 33
 
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
+        multiDexEnabled true
         targetSdkVersion 33
         minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -41,11 +48,6 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
 }

--- a/android/src/main/kotlin/net/wolverinebeach/flutter_timezone/FlutterTimezonePlugin.kt
+++ b/android/src/main/kotlin/net/wolverinebeach/flutter_timezone/FlutterTimezonePlugin.kt
@@ -45,19 +45,11 @@ class FlutterTimezonePlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun getLocalTimezone(): String {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            ZoneId.systemDefault().id
-        } else {
-            TimeZone.getDefault().id
-        }
+        return ZoneId.systemDefault().id
     }
 
     private fun getAvailableTimezones(): List<String> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            ZoneId.getAvailableZoneIds().toCollection(ArrayList())
-        } else {
-            TimeZone.getAvailableIDs().toCollection(ArrayList())
-        }
+        return ZoneId.getAvailableZoneIds().toCollection(ArrayList())
     }
 
     private fun setupMethodChannel(messenger: BinaryMessenger) {

--- a/android/src/main/kotlin/net/wolverinebeach/flutter_timezone/FlutterTimezonePlugin.kt
+++ b/android/src/main/kotlin/net/wolverinebeach/flutter_timezone/FlutterTimezonePlugin.kt
@@ -17,15 +17,6 @@ class FlutterTimezonePlugin : FlutterPlugin, MethodCallHandler {
 
     private lateinit var channel: MethodChannel
 
-    // backward compatibility with flutter api v1
-    companion object {
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val plugin = FlutterTimezonePlugin()
-            plugin.setupMethodChannel(registrar.messenger())
-        }
-    }
-
     override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         setupMethodChannel(binding.binaryMessenger)
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -28,6 +28,12 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 33
 
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -39,6 +45,7 @@ android {
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -56,5 +63,6 @@ flutter {
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Nov 24 23:40:51 AEDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,23 +1,22 @@
 name: flutter_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 1.0.4
+version: 2.0.0
 homepage: https://github.com/tjarvstrand/flutter_timezone
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.12.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter_web_plugins:
     sdk: flutter
   flutter:
     sdk: flutter
-  js: '>=0.6.3 <2.0.0'
+  js: ">=0.6.3 <2.0.0"
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
Whilst looking at some of the recent changes to the fork given the original plugin is now longer maintained, I realised it's got code that does Android version checks to see if it should the newer Java time APIs or not. With desugaring, it's possible now to get rid of this logic so it only uses the newer APIs thatI believe this would bring more consistency. Side effect of this is that AGP gets bump as it needs to be on 7+ to fix [this issue](https://issuetracker.google.com/issues/158060799) that can occur with building using AGP 4.x. Going to 7+ requires bumping the minimum Flutter SDK constraint as the Flutter tooling will otherwise complain about using an unsupported Gradle version

Also removed references to Android v1 embedding as it's no longer needed

Note: my YAML formatting settings switched the pubspec.yaml file to use double quotes automatically on hitting save. Feel free to revert this if single quotes is preferred. Of course, feel free to reject this PR too if you disagree with the changes