### PR TITLE
Adds Android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'net.wolverinebeach.flutter_timezone'
     compileSdkVersion 33
 
     sourceSets {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.example.example'
     compileSdkVersion 33
 
     sourceSets {


### PR DESCRIPTION
Adds a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
See:
https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b