### PR TITLE
Set JVM target for Kotlin language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.7
+
+Android:
+- Set JVM target to Java 8 for Kotlin language. Fix issue [#10](https://github.com/tjarvstrand/flutter_timezone/issues/10).
+
 ## 1.0.6
 
 Re-add lost example file.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 1.0.6
+version: 1.0.7
 homepage: https://github.com/tjarvstrand/flutter_timezone
 
 environment:


### PR DESCRIPTION
Fix issue [#10](https://github.com/tjarvstrand/flutter_timezone/issues/10).