### PR TITLE
Fix JS interop types and return growable list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+logs/*.*

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,7 +33,6 @@ linter:
     - avoid_slow_async_io
     - avoid_type_to_string
     - avoid_types_on_closure_parameters
-    - avoid_unstable_final_fields
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - cancel_subscriptions
@@ -115,7 +114,6 @@ linter:
     - unnecessary_statements
     - unnecessary_to_list_in_spreads
     - unreachable_from_main: false
-    - unsafe_html
     - use_colored_box
     - use_decorated_box
     - use_enums

--- a/lib/flutter_timezone.dart
+++ b/lib/flutter_timezone.dart
@@ -9,7 +9,7 @@ export 'package:flutter_timezone/timezone_info.dart';
 /// Class for getting the native timezone.
 ///
 class FlutterTimezone {
-  static const MethodChannel _channel = const MethodChannel('flutter_timezone');
+  static const MethodChannel _channel = MethodChannel('flutter_timezone');
 
   ///
   /// Returns local timezone from the native layer.
@@ -17,7 +17,8 @@ class FlutterTimezone {
   /// On supported platforms (see README), you can optionally provide a locale code (e.g. "en_US", "de") to get the
   /// localized name of the timezone in that locale, if provided by the underlying platform.
   static Future<TimezoneInfo> getLocalTimezone([String? locale]) async {
-    final localTimezone = await _channel.invokeMethod('getLocalTimezone', locale);
+    final localTimezone =
+        await _channel.invokeMethod('getLocalTimezone', locale);
     if (localTimezone == null) {
       throw ArgumentError('Invalid return from platform getLocalTimezone()');
     }
@@ -32,10 +33,13 @@ class FlutterTimezone {
   ///
   /// On supported platforms (see README), you can optionally provide a locale code (e.g. "en_US", "de") to get the
   /// localized names of the timezones in that locale, if provided by the underlying platform.
-  static Future<List<TimezoneInfo>> getAvailableTimezones([String? locale]) async {
-    final availableTimezones = await _channel.invokeListMethod('getAvailableTimezones', locale);
+  static Future<List<TimezoneInfo>> getAvailableTimezones(
+      [String? locale]) async {
+    final availableTimezones =
+        await _channel.invokeListMethod('getAvailableTimezones', locale);
     if (availableTimezones == null) {
-      throw ArgumentError('Invalid return from platform getAvailableTimezones()');
+      throw ArgumentError(
+          'Invalid return from platform getAvailableTimezones()');
     }
     return availableTimezones.map((timezone) {
       if (timezone is String) {

--- a/lib/flutter_timezone_web.dart
+++ b/lib/flutter_timezone_web.dart
@@ -40,7 +40,7 @@ class FlutterTimezonePlugin {
     if (values == null) {
       return [_getLocalTimeZone()];
     }
-    return values.toDart.map((value) => value.toDart).toList(growable: false);
+    return values.toDart.map((value) => value.toDart).toList();
   }
 }
 

--- a/lib/flutter_timezone_web.dart
+++ b/lib/flutter_timezone_web.dart
@@ -36,13 +36,16 @@ class FlutterTimezonePlugin {
   }
 
   List<String> _getAvailableTimezones() {
-    final function = supportedValuesOf as List<String> Function(String value)?;
-    return function?.call('timeZone') ?? [_getLocalTimeZone()];
+    final values = supportedValuesOf('timeZone'.toJS);
+    if (values == null) {
+      return [_getLocalTimeZone()];
+    }
+    return values.toDart.map((value) => value.toDart).toList(growable: false);
   }
 }
 
 @JS('Intl.supportedValuesOf')
-external JSFunction? supportedValuesOf;
+external JSArray<JSString>? supportedValuesOf(JSString value);
 
 @JS('Intl.DateTimeFormat')
 external _JSDateTimeFormat jsDateTimeFormat();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   meta: ^1.16.0
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 

--- a/test/flutter_timezone_web_test.dart
+++ b/test/flutter_timezone_web_test.dart
@@ -1,0 +1,42 @@
+@TestOn('browser')
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_timezone/flutter_timezone_web.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('web plugin uses real JS interop for timezone data', () async {
+    final plugin = FlutterTimezonePlugin();
+
+    final local =
+        await plugin.handleMethodCall(const MethodCall('getLocalTimezone'));
+    expect(local, isA<String>());
+    expect((local as String).isNotEmpty, isTrue);
+
+    final available = await plugin
+        .handleMethodCall(const MethodCall('getAvailableTimezones'));
+    expect(available, isA<List<String>>());
+    final list = available as List<String>;
+    expect(list.isNotEmpty, isTrue);
+    expect(list.every((value) => value.isNotEmpty), isTrue);
+
+    const stableSample = <String>[
+      'Africa/Abidjan',
+      'Africa/Accra',
+      'Africa/Cairo',
+      'Africa/Johannesburg',
+      'America/New_York',
+      'America/Chicago',
+      'America/Denver',
+      'America/Los_Angeles',
+      'Asia/Tokyo',
+      'Asia/Shanghai',
+      'Europe/London',
+      'Europe/Paris',
+    ];
+    for (final zone in stableSample) {
+      expect(list, contains(zone));
+    }
+  });
+}


### PR DESCRIPTION
## Summary
This PR builds on the work from #58 by @bsutton, which fixes the `invalid_runtime_check_with_js_interop_types` lint by replacing the unsafe cast with proper `dart:js_interop` types.

The only additional change is addressing the review feedback from #58: returning a standard growable list instead of `toList(growable: false)`.

All credit to @bsutton for the original fix — this PR just applies the requested review change to help move things forward.

## Changes (from #58)
- Replace unsafe `supportedValuesOf as List<String> Function(String)?` cast with proper `@JS` external declaration using `JSArray<JSString>`
- Use `dart:js_interop` conversion methods (`.toJS`, `.toDart`)
- Remove deprecated `avoid_unstable_final_fields` and `unsafe_html` lint rules
- Add web-specific unit test for timezone data
- Return growable list (review feedback)