### PR TITLE
Support AGP 9.x compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,12 @@ rootProject.allprojects {
     }
 }
 
+def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (!isAgp9OrAbove) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     namespace 'net.wolverinebeach.flutter_timezone'
@@ -31,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -47,7 +47,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+    if (!isAgp9OrAbove) {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_17
+        }
     }
 }


### PR DESCRIPTION
Starting with Android Gradle Plugin 9.0, Kotlin support is embedded in
AGP itself and applying the standalone `kotlin-android` plugin causes a
build failure.

This PR detects the AGP version and skips both the plugin application
and the `kotlinOptions` block when running on AGP 9 or above, keeping
the existing behavior unchanged for AGP 8.x and below.

Same approach used by [file_picker](https://github.com/miguelpruivo/flutter_file_picker)
since version 10.x.