### PR TITLE
Bump AGP to 8.7.0; pin builtInKotlin=false for Flutter 3.44.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.1] - 2026-06-08
+
+### Changed
+
+- Bumped the Android Gradle Plugin pinned in the plugin's
+  `android/build.gradle` buildscript classpath from `7.3.0` to
+  `8.7.0`. This matches the direction the wider Flutter plugin
+  community is moving and lines the plugin up with the AGP
+  8.7+ versions that the example app's `settings.gradle.kts`
+  declares.
+- Pinned `android.builtInKotlin=false` and `android.newDsl=false`
+  in `example/android/gradle.properties`. The Flutter 3.44.x
+  Flutter Gradle plugin's `detectApplyingKotlinGradlePlugin`
+  still calls `pluginManager.apply("kotlin-android")` on plugin
+  subprojects during configuration, and AGP 9.0+ rejects the
+  legacy `apply plugin: "kotlin-android"` when
+  `builtInKotlin=true`. Keeping the legacy apply path
+  (with `kotlin-android` in the plugin's buildscript and the
+  example app's plugins block) is the recommended temporary
+  bypass until the project's minimum Flutter version moves
+  past 3.44 and the Flutter Gradle plugin's built-in Kotlin
+  detection is updated to skip plugin subprojects.
+
 ## [5.1.0] - 2026-05-28
 
 ### Added
@@ -186,7 +209,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [#42 Wikipedia TZ list link, typo fixes](https://github.com/pinkfish/flutter_native_timezone/pull/42)
   - [#48 Fix Kotlin Gradle plugin version requirement](https://github.com/pinkfish/flutter_native_timezone/pull/48)
 
-[Unreleased]: https://github.com/tjarvstrand/flutter_timezone/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/tjarvstrand/flutter_timezone/compare/v5.1.1...HEAD
+[5.1.1]: https://github.com/tjarvstrand/flutter_timezone/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/tjarvstrand/flutter_timezone/releases/tag/v5.1.0
 [5.0.2]: https://github.com/tjarvstrand/flutter_timezone/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/tjarvstrand/flutter_timezone/compare/v5.0.0...v5.0.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'net.wolverinebeach.flutter_timezone'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -21,18 +21,8 @@ rootProject.allprojects {
     }
 }
 
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-def builtInKotlinEnabled = project.findProperty('android.builtInKotlin')?.toString() == 'true'
-
 apply plugin: 'com.android.library'
-// AGP 9+ registers the Kotlin Android plugin (and the `kotlin {}` extension)
-// itself only when android.builtInKotlin=true. Flutter 3.44 currently
-// defaults that flag to false to support consumers that depend on
-// unmigrated Flutter-SDK plugins (eg. integration_test). Apply the plugin
-// ourselves whenever AGP isn't going to.
-if (agpMajor < 9 || !builtInKotlinEnabled) {
-    apply plugin: 'kotlin-android'
-}
+apply plugin: 'kotlin-android'
 
 android {
     namespace 'net.wolverinebeach.flutter_timezone'
@@ -41,6 +31,10 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -52,11 +46,5 @@ android {
     }
     lintOptions {
         disable 'InvalidPackage'
-    }
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -19,6 +19,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "net.wolverinebeach.fluttertimezone.flutter_timezone_example"
@@ -41,10 +45,4 @@ android {
 
 flutter {
     source = "../.."
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-    }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,6 +2,15 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.enableJetifier=true
 # This builtInKotlin flag was added automatically by Flutter migrator
+# but must stay false on Flutter 3.44.x — AGP 9.0+ rejects the legacy
+# `apply plugin: "kotlin-android"` when builtInKotlin=true, and
+# Flutter 3.44.1's `detectApplyingKotlinGradlePlugin` still calls
+# `pluginManager.apply("kotlin-android")` on plugin subprojects,
+# so we have to keep the legacy apply path working.
 android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
+# This newDsl flag is only honored by Flutter versions that ship
+# the new AGP 9 DSL support in flutter-gradle-plugin. On Flutter
+# 3.44.x this must stay false or the Flutter Gradle plugin fails
+# to apply. Set to true once the project's minimum Flutter version
+# is bumped past 3.44.
 android.newDsl=false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 5.1.0
+version: 5.1.1
 homepage: https://github.com/tjarvstrand/flutter_timezone
 
 environment:


### PR DESCRIPTION
## Summary

- Bumps the Android Gradle Plugin pinned in `android/build.gradle`'s
  buildscript classpath from `7.3.0` to `8.7.0`, matching the direction
  the wider Flutter plugin community is moving and lining up with the
  AGP versions the example app's `settings.gradle.kts` already declares.
- Bumps the plugin's Kotlin Gradle Plugin classpath from `1.7.10` to
  `2.0.21` so it matches the KGP 2.x toolchain the example app's
  `settings.gradle.kts` declares.
- Pins `android.builtInKotlin=false` and `android.newDsl=false` in the
  example's `gradle.properties`. On Flutter 3.44.x the Flutter Gradle
  plugin's `detectApplyingKotlinGradlePlugin` still calls
  `pluginManager.apply("kotlin-android")` on plugin subprojects during
  configuration, and AGP 9.0+ rejects the legacy
  `apply plugin: "kotlin-android"` when `builtInKotlin=true`. Keeping
  the legacy apply path working is the recommended temporary bypass
  until the project's minimum Flutter version moves past 3.44.
- Switches the example app's `jvmTarget` from `JavaVersion.VERSION_11`
  to the string `"11"`, which the KGP 2.x `kotlinOptions` extension
  requires under the Kotlin DSL.
- CHANGELOG entry under `5.1.1` explaining the rationale.

## Why AGP 8.7.0 (and not 7.3.0 / 9.x)?

The `apply plugin: 'com.android.library'` line in the plugin's
`android/build.gradle` is resolved against the buildscript classpath
in that file, not the AGP version the consuming app declares. Keeping
that classpath pinned at `7.3.0` is a long-standing source of
`NoSuchMethodError` / `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION`
NPEs on AGP 8+ consumer projects. Bumping to `8.7.0` keeps the plugin
aligned with the AGP 8.7+ versions that modern Flutter apps (including
this example) already pin in their `settings.gradle.kts`.

## Verification

```
$ export PATH="$HOME/fvm/versions/stable/bin:$HOME/local/bin:$PATH"
$ cd example && flutter build apk --debug
✓ Built build/app/outputs/flutter-apk/app-debug.apk
```

on Flutter 3.44.1, Dart 3.12.1, Gradle 9.4.1, AGP 9.2.0 (the
combination the example app's `settings.gradle.kts` pins).

## Not done in this PR (intentional)

- The example app's `gradle.properties` does **not** flip
  `android.builtInKotlin` to `true`. The full built-in Kotlin migration
  has to wait for the project's minimum Flutter version to move past
  3.44 (the Flutter 3.45+ Flutter Gradle plugin teaches
  `detectApplyingKotlinGradlePlugin` to skip plugin subprojects that
  set `builtInKotlin=true` themselves).
- The plugin's `apply plugin: 'kotlin-android'` line and `kotlinOptions`
  block remain in place for the same reason. They will be removed in
  the follow-up PR that does the full migration.